### PR TITLE
Adding note about uploading from URL

### DIFF
--- a/help/quicksilver/workfront-fusion/mapping/about-mapping-files.md
+++ b/help/quicksilver/workfront-fusion/mapping/about-mapping-files.md
@@ -52,6 +52,8 @@ Modules that have the ability to work with files require two pieces of informati
 
 When you map a file, you choose the modules in your scenario from which you want to obtain the data. The file name and file content are then automatically mapped as they are.
 
+**Note:** If you need to process a file from a URL, we recommend to use the `HTTP > Get a File` module to download the file from the URL, and then map the file from the `HTTP > Get a File` module to the desired module's field in your scenario.
+
 >[!INFO]
 >
 >**Example:** This example shows how to download documents from Adobe Workfront to Google Drive. The Workfront trigger Watch Record returns detailed information about each document, including its name and ID.


### PR DESCRIPTION
See the info tip at https://www.make.com/en/help/mapping/working-with-files. If uploading from a URL, you need to use an `HTTP>Get a File` module to get the file contents before it can be uploaded to a service.